### PR TITLE
Precision of microtime() on Windows is very poor, replace with uniqid()

### DIFF
--- a/phpQuery/phpQuery.php
+++ b/phpQuery/phpQuery.php
@@ -487,7 +487,7 @@ abstract class phpQuery
 			throw new Exception("Old PHP4 DOM XML extension detected. phpQuery won't work until this extension is enabled.");
 //		$id = $documentID
 //			? $documentID
-//			: md5(microtime());
+//			: md5(uniqid('', true));
 		$document = null;
 		if ($html instanceof DOMDOCUMENT) {
 			if (self::getDocumentID($html)) {
@@ -731,7 +731,7 @@ abstract class phpQuery
 			$options['dataType'] = 'json';
 		}
 		if (isset($options['dataType']) && $options['dataType'] == 'json') {
-			$jsonpCallback = 'json_'.md5(microtime());
+			$jsonpCallback = 'json_'.md5(uniqid('', true));
 			$jsonpData = $jsonpUrl = false;
 			if ($options['data']) {
 				foreach($options['data'] as $n => $v) {

--- a/phpQuery/phpQuery/DOMDocumentWrapper.php
+++ b/phpQuery/phpQuery/DOMDocumentWrapper.php
@@ -49,7 +49,7 @@ class DOMDocumentWrapper {
 			$this->load($markup, $contentType, $newDocumentID);
 		$this->id = $newDocumentID
 			? $newDocumentID
-			: md5(microtime());
+			: md5(uniqid('', true));
 	}
 	public function load($markup, $contentType = null, $newDocumentID = null) {
 //		phpQuery::$documents[$id] = $this;


### PR DESCRIPTION
If you try to add check for hash collision of DocumentID, you will see that the issue exists on Microsoft Windows:

```php
        $this->id = $newDocumentID
            ? $newDocumentID
            : md5(uniqid('', true));
        if (array_key_exists($this->id, phpQuery::$documents)) {
            throw new \ErrorException('DocumentID hash collision');
        }
```