### PR TITLE
Fix ability to match classes containing new-lines

### DIFF
--- a/phpQuery/phpQuery/phpQueryObject.php
+++ b/phpQuery/phpQuery/phpQueryObject.php
@@ -605,7 +605,7 @@ class phpQueryObject
 				// strip leading dot from class name
 				substr($class, 1),
 				// get classes for element as array
-				explode(' ', $node->getAttribute('class') )
+				preg_split('/\s/', $node->getAttribute('class') )
 			);
 		}
 	}


### PR DESCRIPTION
Consider a tag with class attribute containing new-lines and you are trying to match the tag using a selector:

```php
$html = '<div class="ProductBuyBoxCmsBlock_pricing_display">
<span class="ProductBuyBoxCmsBlock_pricing_display_list_price">
      List Price: <span>$222.95</span></span><br><span class="ProductBuyBoxCmsBlock_pricing_display_product_price
      on_sale
      ">
          Price: $199.95
              </span>
</div>';
$doc = phpQuery::newDocument($html);
$price = $doc->find('.ProductBuyBoxCmsBlock_pricing_display .ProductBuyBoxCmsBlock_pricing_display_product_price"]')->text();
```

`matchClasses()` function uses explode(' ') and both classes of that tag will contain trailing new-line characters and the selector ".ProductBuyBoxCmsBlock_pricing_display_product_price" will fail to match.